### PR TITLE
option for loader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/liuzl/gocc
+
+go 1.16
+
+require (
+	github.com/liuzl/cedar-go v0.0.0-20170805034717-80a9c64b256d // indirect
+	github.com/liuzl/da v0.0.0-20180704015230-14771aad5b1d
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/liuzl/cedar-go v0.0.0-20170805034717-80a9c64b256d h1:qSmEGTgjkESUX5kPMSGJ4pcBUtYVDdkNzMrjQyvRvp0=
+github.com/liuzl/cedar-go v0.0.0-20170805034717-80a9c64b256d/go.mod h1:x7SghIWwLVcJObXbjK7S2ENsT1cAcdJcPl7dRaSFog0=
+github.com/liuzl/da v0.0.0-20180704015230-14771aad5b1d h1:hTRDIpJ1FjS9ULJuEzu69n3qTgc18eI+ztw/pJv47hs=
+github.com/liuzl/da v0.0.0-20180704015230-14771aad5b1d/go.mod h1:7xD3p0XnHvJFQ3t/stEJd877CSIMkH/fACVWen5pYnc=

--- a/loader.go
+++ b/loader.go
@@ -1,0 +1,17 @@
+package gocc
+
+import (
+	"io"
+	"os"
+)
+
+type Loader interface {
+	Open(filepath string) (io.ReadCloser, error)
+}
+
+type OSLoader struct {
+}
+
+func (OSLoader) Open(filepath string) (io.ReadCloser, error) {
+	return os.Open(filepath)
+}

--- a/option.go
+++ b/option.go
@@ -1,0 +1,42 @@
+package gocc
+
+var defaultOptions = options{
+	dir:    DefaultDir(),
+	loader: OSLoader{},
+}
+
+type options struct {
+	dir    string
+	loader Loader
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type funcOption struct {
+	f func(*options)
+}
+
+func (fdo *funcOption) apply(do *options) {
+	fdo.f(do)
+}
+func newFuncOption(f func(*options)) *funcOption {
+	return &funcOption{
+		f: f,
+	}
+}
+func WithDir(dir string) Option {
+	return newFuncOption(func(o *options) {
+		o.dir = dir
+	})
+}
+func WithLoader(loader Loader) Option {
+	return newFuncOption(func(o *options) {
+		if loader == nil {
+			o.loader = OSLoader{}
+		} else {
+			o.loader = loader
+		}
+	})
+}


### PR DESCRIPTION
本喵一直用你的 gocc 來轉換中文，多謝。

近日需要用 golang 寫一個庫供手機使用，gocc 從固定檔案夾加載配置的方式不方便部署到手機，於是本喵 fork 後修改了下(當然保證和之前的 api 完全兼容)。本喵的修改如下

1. 現在 gocc.New 函數從第二個參數開始是可選長度的 interface Option 參數
2. WithDir 創建一個 Option 指定 defaultDir 而非使用默認的 defaultDir 路徑
3. WithLoader 指定一個 檔案加載器 負責加載 opencc 的配置

因爲 Option 都是可選的，所以在沒傳遞 Option時和原 api 完全兼容。WithLoader 的存在 本喵可以將配置嵌入到 go代碼並實現一個 loader 來讀取嵌入go中的配置以方便部署到手機

```
type Loader interface {
	Open(filepath string) (io.ReadCloser, error)
}
func WithLoader(loader Loader) Option
func New(conversion string, option ...Option) (*OpenCC, error) 
```